### PR TITLE
More conservative approach to handle errors in area_def_names_to_extent()

### DIFF
--- a/mpop/satin/mipp_xrit.py
+++ b/mpop/satin/mipp_xrit.py
@@ -159,7 +159,11 @@ def load_generic(satscene, options, calibrate=True, area_extent=None,
             # lon0=0.0), that is, do not pass default_extent=area_extent
             else:
                 area_extent = area_def_names_to_extent(area_def_names,
-                                                       metadata.proj4_params)
+                                                       metadata.proj4_params,
+                                                       default_extent=None)
+                
+            if area_extent is None:
+                LOGGER.info('Could not derive area_extent from area_def_names')
 
             area_converted_to_extent = True
 


### PR DESCRIPTION
As discussed on slack-channel "trollduction" (2016/05/04):

Calculation of bounding box fails due to proj4 issues. A related issue can be found in https://hub.qgis.org/issues/4302 :

> On further examination of the GEOS projection I find that PROJ (the library that QGIS uses to do reprojection) cannot handle long/lat data greater than +/- 81.3 degrees (approximately) from the projection center, either forward or reverse. Anything outside of this range will cause a projection failure, consequently the object may not be displayed, or there will be an error message detailing the failure.

Without this patch, the function ignores invalid values. This results in wrong area extents and mpop/mipp does not read necessary satellite date from file.

With this patch, you can set the parameter "default_extent" to None. If so and invalid values occur during calculation of area_extent, "None" will be returned. In that case, scene.load will be called with no area_extent and (hopefully) loads all data (tested with Himawri 8 reader).