### PR TITLE
Feature writer options

### DIFF
--- a/mpop/imageo/formats/ninjotiff.py
+++ b/mpop/imageo/formats/ninjotiff.py
@@ -403,7 +403,8 @@ def _finalize(geo_image, dtype=np.uint8, value_range_measurement_unit=None, data
                          str(geo_image.mode))
 
 
-def save(geo_image, filename, writer_options=None, ninjo_product_name=None, **kwargs):
+def save(geo_image, filename, ninjo_product_name=None, writer_options=None,
+         **kwargs):
     """MPOP's interface to Ninjo TIFF writer.
 
     :Parameters:

--- a/mpop/imageo/formats/ninjotiff.py
+++ b/mpop/imageo/formats/ninjotiff.py
@@ -44,6 +44,7 @@ from datetime import datetime
 import numpy as np
 
 from mpop.imageo.formats import tifffile
+import mpop.imageo.formats.writer_options as write_opts
 
 log = logging.getLogger(__name__)
 
@@ -402,7 +403,7 @@ def _finalize(geo_image, dtype=np.uint8, value_range_measurement_unit=None, data
                          str(geo_image.mode))
 
 
-def save(geo_image, filename, ninjo_product_name=None, **kwargs):
+def save(geo_image, filename, writer_options=None, ninjo_product_name=None, **kwargs):
     """MPOP's interface to Ninjo TIFF writer.
 
     :Parameters:
@@ -413,6 +414,9 @@ def save(geo_image, filename, ninjo_product_name=None, **kwargs):
     :Keywords:
         ninjo_product_name : str
             Optional index to Ninjo configuration file.
+        writer_options : dict
+            options dictionary as defined in MPOP interface 
+            See _write
         kwargs : dict
             See _write
 
@@ -423,6 +427,12 @@ def save(geo_image, filename, ninjo_product_name=None, **kwargs):
         * min value will be reserved for transparent color.
         * If possible mpop.imageo.image's standard finalize will be used.
     """
+
+    if writer_options:
+        # add writer_options
+        kwargs.update(writer_options)
+        if 'ninjo_product_name' in writer_options:
+            ninjo_product_name = writer_options['ninjo_product_name']
 
     dtype = np.uint8
     if 'nbits' in kwargs:

--- a/mpop/imageo/formats/writer_options.py
+++ b/mpop/imageo/formats/writer_options.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2016.
+
+# Author(s):
+
+#   Christian Kliche <christian.kliche@ebp.de>
+
+# This file is part of the mpop.
+
+# mpop is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# mpop is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with mpop.  If not, see <http://www.gnu.org/licenses/>.
+'''
+Module for writer option constants
+'''
+WR_OPT_NBITS = 'nbits'
+WR_OPT_COMPRESSION = 'compression'
+WR_OPT_BLOCKSIZE = 'blocksize'

--- a/mpop/imageo/geo_image.py
+++ b/mpop/imageo/geo_image.py
@@ -131,7 +131,9 @@ class GeoImage(Image):
             except ImportError:
                 raise  UnknownImageFormat(
                     "Unknown image format '%s'" % fformat)
-            saver.save(self, filename, writer_options, **kwargs)
+            kwargs = kwargs or {}
+            kwargs['writer_options'] = writer_options
+            saver.save(self, filename, **kwargs)
 
     def _gdal_write_channels(self, dst_ds, channels, opacity, fill_value):
         """Write *channels* in a gdal raster structure *dts_ds*, using

--- a/mpop/imageo/geo_image.py
+++ b/mpop/imageo/geo_image.py
@@ -45,6 +45,7 @@ except ImportError:
 from mpop import CONFIG_PATH
 import logging
 from mpop.utils import ensure_dir
+import mpop.imageo.formats.writer_options as write_opts
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +75,7 @@ class GeoImage(Image):
 
     def save(self, filename, compression=6,
              tags=None, gdal_options=None,
-             fformat=None, blocksize=256, **kwargs):
+             fformat=None, blocksize=256, writer_options=None, **kwargs):
         """Save the image to the given *filename*. If the extension is "tif",
         the image is saved to geotiff_ format, in which case the *compression*
         level can be given ([0, 9], 0 meaning off). See also
@@ -84,14 +85,37 @@ class GeoImage(Image):
         options for the gdal saving driver. A *blocksize* other than 0 will
         result in a tiled image (if possible), with tiles of size equal to
         *blocksize*.
-
         If the specified format *fformat* is not know to MPOP (and PIL), we
         will try to import module *fformat* and call the method `fformat.save`.
 
+        Use *writer_options* to define parameters that should be forwarded to
+        custom writers. Dictionary keys listed in
+        mpop.imageo.formats.writer_options will be interpreted by this
+        function instead of *compression*, *blocksize* and nbits in
+        *tags* dict.
 
         .. _geotiff: http://trac.osgeo.org/geotiff/
         """
         fformat = fformat or os.path.splitext(filename)[1][1:]
+
+        # prefer parameters in writer_options dict
+        # fill dict if parameters are missing
+        writer_options = writer_options or {}
+        tags = tags or {}
+        if writer_options.get(write_opts.WR_OPT_COMPRESSION, None):
+            compression = writer_options[write_opts.WR_OPT_COMPRESSION]
+        elif compression is not None:
+            writer_options[write_opts.WR_OPT_COMPRESSION] = compression
+
+        if writer_options.get(write_opts.WR_OPT_BLOCKSIZE, None):
+            blocksize = writer_options[write_opts.WR_OPT_BLOCKSIZE]
+        elif blocksize is not None:
+            writer_options[write_opts.WR_OPT_BLOCKSIZE] = blocksize
+
+        if writer_options.get(write_opts.WR_OPT_NBITS, None):
+            tags['NBITS'] = writer_options[write_opts.WR_OPT_NBITS]
+        elif tags.get('NBITS') is not None:
+            writer_options[write_opts.WR_OPT_NBITS] = tags.get('NBITS')
 
         if fformat.lower() in ('tif', 'tiff'):
             return self.geotiff_save(filename, compression, tags,
@@ -107,7 +131,7 @@ class GeoImage(Image):
             except ImportError:
                 raise  UnknownImageFormat(
                     "Unknown image format '%s'" % fformat)
-            saver.save(self, filename, **kwargs)
+            saver.save(self, filename, writer_options, **kwargs)
 
     def _gdal_write_channels(self, dst_ds, channels, opacity, fill_value):
         """Write *channels* in a gdal raster structure *dts_ds*, using

--- a/mpop/tests/test_geo_image.py
+++ b/mpop/tests/test_geo_image.py
@@ -75,6 +75,14 @@ class TestGeoImage(unittest.TestCase):
         self.img.save("test.tif", compression=9, tags={"NBITS": 20})
         mock_save.assert_called_once_with("test.tif", 9, {"NBITS": 20},
                                           None, 256)
+        mock_save.reset_mock()
+        self.img.save("test.tif", writer_options={"compression":9})
+        mock_save.assert_called_once_with("test.tif", 9, {}, None, 256)
+        
+        mock_save.reset_mock()
+        self.img.save("test.tif", writer_options={"compression":9, "nbits":16})
+        mock_save.assert_called_once_with("test.tif", 9, {"NBITS": 16},
+                                          None, 256)
 
         with patch.object(geo_image.Image, 'save') as mock_isave:
             self.img.save("test.png")

--- a/mpop/tests/test_geo_image.py
+++ b/mpop/tests/test_geo_image.py
@@ -62,13 +62,13 @@ class TestGeoImage(unittest.TestCase):
         """
         
         self.img.save("test.tif", compression=0)
-        mock_save.assert_called_once_with("test.tif", 0, None, None, 256)
+        mock_save.assert_called_once_with("test.tif", 0, {}, None, 256)
         mock_save.reset_mock()
         self.img.save("test.tif", compression=9)
-        mock_save.assert_called_once_with("test.tif", 9, None, None, 256)
+        mock_save.assert_called_once_with("test.tif", 9, {}, None, 256)
         mock_save.reset_mock()
         self.img.save("test.tif", compression=9, floating_point=True)
-        mock_save.assert_called_once_with("test.tif", 9, None, None, 256,
+        mock_save.assert_called_once_with("test.tif", 9, {}, None, 256,
                                           floating_point=True)
 
         mock_save.reset_mock()


### PR DESCRIPTION
GeoImage.save extended by writer_options dict  

Some dict keys for options  used by GeoImage.save
are defined in writer_options.py.
All options within this dict will be forwarded to custom writers
like NinJoTiff writer module.