### PR TITLE
New option fill_value_subst

### DIFF
--- a/mpop/imageo/formats/writer_options.py
+++ b/mpop/imageo/formats/writer_options.py
@@ -26,3 +26,4 @@ Module for writer option constants
 WR_OPT_NBITS = 'nbits'
 WR_OPT_COMPRESSION = 'compression'
 WR_OPT_BLOCKSIZE = 'blocksize'
+WR_OPT_FILL_VALUE_SUBST = 'fill_value_subst'


### PR DESCRIPTION
This option can be used in conjunction with GeoImage.fill_value. Any occurrences of
fill_value within the image data will be replaced with fill_value_subst before storing
to image file.

Example trollduction configuration to use this feature:
```
<file>test.tif
	<format_params>
		<fill_value_subst>1</fill_value_subst>
	</format_params>
</file>
```