### PR TITLE
Feature bilinear

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: python
 python:
-- '2.6'
 - '2.7'
 install:
-- if [[ $TRAVIS_PYTHON_VERSION == "2.6" ]]; then pip install "pillow<4.0.0"; fi
 - pip install .
 - pip install coveralls
 - pip install pyorbital

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
 - '2.6'
 - '2.7'
 install:
+- if [[ $TRAVIS_PYTHON_VERSION == "2.6" ]]; then pip install "pillow<4.0.0"; fi
 - pip install .
 - pip install coveralls
 - pip install pyorbital

--- a/mpop/projector.py
+++ b/mpop/projector.py
@@ -311,5 +311,6 @@ class Projector(object):
                                            self._cache['input_idxs'],
                                            self._cache['idx_arr'],
                                            output_shape=self.out_area.shape)
+            res = np.ma.masked_invalid(res)
 
         return res

--- a/mpop/projector.py
+++ b/mpop/projector.py
@@ -228,12 +228,12 @@ class Projector(object):
                 self._cache['ewa_rows'] = rows
 
             elif self.mode == "bilinear":
-                from pyresample.bilinear import calc_params
+                from pyresample.bilinear import get_bil_info
 
                 bilinear_t, bilinear_s, input_idxs, idx_arr = \
-                    calc_params(self.in_area, self.out_area,
-                                self.radius, neighbours=32,
-                                nprocs=nprocs, masked=False)
+                    get_bil_info(self.in_area, self.out_area,
+                                 self.radius, neighbours=32,
+                                 nprocs=nprocs, masked=False)
 
                 self._cache = {}
                 self._cache['bilinear_s'] = bilinear_s
@@ -297,7 +297,7 @@ class Projector(object):
                                            rows_per_scan=rows_per_scan)
 
         elif self.mode == "bilinear":
-            from pyresample.bilinear import resample_bilinear
+            from pyresample.bilinear import get_sample_from_bil_info
 
             if not 'bilinear_t' in self._cache:
                 self._cache['bilinear_t'] = self._file_cache['bilinear_t']
@@ -305,10 +305,11 @@ class Projector(object):
                 self._cache['input_idxs'] = self._file_cache['input_idxs']
                 self._cache['idx_arr'] = self._file_cache['idx_arr']
 
-            res = resample_bilinear(data, self._cache['bilinear_t'],
-                                    self._cache['bilinear_s'],
-                                    self._cache['input_idxs'],
-                                    self._cache['idx_arr'],
-                                    self.out_area.shape)
+            res = get_sample_from_bil_info(data.ravel(),
+                                           self._cache['bilinear_t'],
+                                           self._cache['bilinear_s'],
+                                           self._cache['input_idxs'],
+                                           self._cache['idx_arr'],
+                                           output_shape=self.out_area.shape)
 
         return res

--- a/mpop/projector.py
+++ b/mpop/projector.py
@@ -103,7 +103,7 @@ class Projector(object):
     - 'ewa'
     - 'nearest'.
     *radius* defines the radius of influence for nearest neighbour
-    search in 'nearest' mode.
+    search in 'nearest' and 'bilinear' modes.
     """
 
     def __init__(self, in_area, out_area,

--- a/mpop/projector.py
+++ b/mpop/projector.py
@@ -39,6 +39,8 @@ import logging
 
 import numpy as np
 from pyresample import image, utils, geometry, kd_tree
+from pyresample.bilinear import get_sample_from_bil_info, get_bil_info
+
 from mpop import CONFIG_PATH
 
 logger = logging.getLogger(__name__)
@@ -228,7 +230,6 @@ class Projector(object):
                 self._cache['ewa_rows'] = rows
 
             elif self.mode == "bilinear":
-                from pyresample.bilinear import get_bil_info
 
                 bilinear_t, bilinear_s, input_idxs, idx_arr = \
                     get_bil_info(self.in_area, self.out_area,
@@ -297,9 +298,8 @@ class Projector(object):
                                            rows_per_scan=rows_per_scan)
 
         elif self.mode == "bilinear":
-            from pyresample.bilinear import get_sample_from_bil_info
 
-            if not 'bilinear_t' in self._cache:
+            if 'bilinear_t' not in self._cache:
                 self._cache['bilinear_t'] = self._file_cache['bilinear_t']
                 self._cache['bilinear_s'] = self._file_cache['bilinear_s']
                 self._cache['input_idxs'] = self._file_cache['input_idxs']

--- a/mpop/projector.py
+++ b/mpop/projector.py
@@ -233,7 +233,7 @@ class Projector(object):
                 bilinear_t, bilinear_s, input_idxs, idx_arr = \
                     calc_params(self.in_area, self.out_area,
                                 self.radius, neighbours=32,
-                                nprocs=nprocs)
+                                nprocs=nprocs, masked=False)
 
                 self._cache = {}
                 self._cache['bilinear_s'] = bilinear_s

--- a/mpop/projector.py
+++ b/mpop/projector.py
@@ -95,11 +95,15 @@ class Projector(object):
     generated projectors can be saved to disk for later reuse. Use the
     :meth:`save` method for this.
 
-    To define a projector object, on has to specify *in_area* and *out_area*,
-    and can also input the *in_lonlats* or the *mode* ('quick' which works only
-    if both in- and out-areas are AreaDefinitions, or 'nearest'). *radius*
-    defines the radius of influence for nearest neighbour search in 'nearest'
-    mode.
+    To define a projector object, on has to specify *in_area* and
+    *out_area*, and can also input the *in_lonlats* or the *mode*.
+    Available modes area:
+    - 'quick' (works only if both in- and out-areas are AreaDefinitions)
+    - 'bilinear' (out-area needs to be AreaDefinition with proj4_string)
+    - 'ewa'
+    - 'nearest'.
+    *radius* defines the radius of influence for nearest neighbour
+    search in 'nearest' mode.
     """
 
     def __init__(self, in_area, out_area,
@@ -136,6 +140,7 @@ class Projector(object):
                 self.in_area = in_area
             except AttributeError:
                 try:
+                    # TODO: Note that latlons are in order (lons, lats)
                     self.in_area = geometry.SwathDefinition(lons=in_latlons[0],
                                                             lats=in_latlons[1])
                     in_id = in_area

--- a/mpop/tests/test_projector.py
+++ b/mpop/tests/test_projector.py
@@ -4,11 +4,11 @@
 
 # SMHI,
 # Folkborgsvägen 1,
-# Norrköping, 
+# Norrköping,
 # Sweden
 
 # Author(s):
- 
+
 #   Martin Raspaud <martin.raspaud@smhi.se>
 #   Adam Dybbroe <adam.dybbroe@smhi.se>
 
@@ -37,6 +37,7 @@ import numpy as np
 from mock import MagicMock, patch
 import sys
 sys.modules['pyresample'] = MagicMock()
+sys.modules['pyresample.bilinear'] = MagicMock()
 
 from pyresample import geometry, utils
 
@@ -44,12 +45,13 @@ from mpop.projector import Projector
 import mpop.projector
 
 
-
 class TestProjector(unittest.TestCase):
+
     """Class for testing the Projector class.
     """
 
     proj = None
+
     @patch.object(utils, 'generate_quick_linesample_arrays')
     @patch.object(mpop.projector.kd_tree, 'get_neighbour_info')
     @patch.object(mpop.projector, '_get_area_hash')
@@ -61,7 +63,6 @@ class TestProjector(unittest.TestCase):
 
         self.assertRaises(TypeError, Projector)
         self.assertRaises(TypeError, Projector, random_string(20))
-
 
         # in case of string arguments
 
@@ -78,11 +79,8 @@ class TestProjector(unittest.TestCase):
         utils.parse_area_file.assert_any_call(area_file, in_area_id)
         utils.parse_area_file.assert_any_call(area_file, out_area_id)
 
-
-
         self.assertEquals(self.proj.in_area, area_type)
         self.assertEquals(self.proj.out_area, area_type)
-
 
         # in case of undefined areas
 
@@ -109,18 +107,21 @@ class TestProjector(unittest.TestCase):
                 self.assertEquals(self.proj.in_area, in_area)
 
         in_area = geometry.SwathDefinition()
-        utils.parse_area_file.return_value.__getitem__.side_effect = [AttributeError, out_area_id]
+        utils.parse_area_file.return_value.__getitem__.side_effect = [
+            AttributeError, out_area_id]
         self.proj = Projector(in_area, out_area_id)
         self.assertEquals(self.proj.in_area, in_area)
 
         out_area = geometry.AreaDefinition()
-        utils.parse_area_file.return_value.__getitem__.side_effect = [in_area_id, AttributeError]
+        utils.parse_area_file.return_value.__getitem__.side_effect = [
+            in_area_id, AttributeError]
         self.proj = Projector(in_area_id, out_area)
         self.assertEquals(self.proj.out_area, out_area)
 
         # in case of lon/lat is input
 
-        utils.parse_area_file.return_value.__getitem__.side_effect = [AttributeError, out_area_id]
+        utils.parse_area_file.return_value.__getitem__.side_effect = [
+            AttributeError, out_area_id]
         lonlats = ("great_lons", "even_greater_lats")
 
         self.proj = Projector("raise", out_area_id, lonlats)
@@ -153,7 +154,6 @@ class TestProjector(unittest.TestCase):
         self.assertTrue(cache['valid_output_index'] is not None)
         self.assertTrue(cache['index_array'] is not None)
 
-
     @patch.object(np.ma, "array")
     @patch.object(mpop.projector.kd_tree, 'get_sample_from_neighbour_info')
     @patch.object(np, "load")
@@ -164,17 +164,18 @@ class TestProjector(unittest.TestCase):
         out_area_id = random_string(20)
         data = np.random.standard_normal((3, 1))
 
-        utils.parse_area_file.return_value.__getitem__.side_effect = ["a", "b", "c", "d"]
+        utils.parse_area_file.return_value.__getitem__.side_effect = [
+            "a", "b", "c", "d"]
         # test quick
         self.proj = Projector(in_area_id, out_area_id, mode="quick")
         self.proj.project_array(data)
-        mpop.projector.image.ImageContainer.assert_called_with(\
+        mpop.projector.image.ImageContainer.assert_called_with(
             data, "a", fill_value=None)
         mpop.projector.image.ImageContainer.return_value.\
-            get_array_from_linesample.assert_called_with(\
-            self.proj._cache["row_idx"], self.proj._cache["col_idx"])
-        marray.assert_called_once_with(\
-            mpop.projector.image.ImageContainer.return_value.\
+            get_array_from_linesample.assert_called_with(
+                self.proj._cache["row_idx"], self.proj._cache["col_idx"])
+        marray.assert_called_once_with(
+            mpop.projector.image.ImageContainer.return_value.
             get_array_from_linesample.return_value,
             dtype=np.dtype('float64'))
 
@@ -182,17 +183,17 @@ class TestProjector(unittest.TestCase):
         in_area = MagicMock()
         out_area = MagicMock()
         utils.parse_area_file.return_value.__getitem__.side_effect = \
-                        [in_area, out_area]
+            [in_area, out_area]
         self.proj = Projector(in_area_id, out_area_id, mode="nearest")
         self.proj.project_array(data)
         mpop.projector.kd_tree.get_sample_from_neighbour_info.\
-             assert_called_with('nn',
-                                out_area.shape,
-                                data,
-                                npload.return_value.__getitem__.return_value,
-                                npload.return_value.__getitem__.return_value,
-                                npload.return_value.__getitem__.return_value,
-                                fill_value=None)
+            assert_called_with('nn',
+                               out_area.shape,
+                               data,
+                               npload.return_value.__getitem__.return_value,
+                               npload.return_value.__getitem__.return_value,
+                               npload.return_value.__getitem__.return_value,
+                               fill_value=None)
 
 
 def random_string(length,
@@ -214,4 +215,3 @@ def suite():
     mysuite.addTest(loader.loadTestsFromTestCase(TestProjector))
 
     return mysuite
-


### PR DESCRIPTION
Added access to pyresample.bilinear as a new resampling method. Includes caching for the resampling coefficients, and they can be saved to disk and re-used (with precompute=True argument) in the same way as with nearest neighbour resampling.