### PR TITLE
Refactor mpop.projector and add a script for pre-calculating projection parameters

### DIFF
--- a/mpop/tests/test_projector.py
+++ b/mpop/tests/test_projector.py
@@ -30,9 +30,7 @@
 """Test module for mpop.projector.
 """
 import unittest
-
 import numpy as np
-
 
 from mock import MagicMock, patch
 import sys
@@ -104,7 +102,6 @@ class TestProjector(unittest.TestCase):
             with patch.object(utils, 'parse_area_file', mock):
                 in_area = geometry.AreaDefinition()
                 self.proj = Projector(in_area, out_area_id)
-                print self.proj.in_area
                 self.assertEquals(self.proj.in_area, in_area)
 
         in_area = geometry.SwathDefinition()

--- a/mpop/tests/test_projector.py
+++ b/mpop/tests/test_projector.py
@@ -206,6 +206,82 @@ class TestProjector(unittest.TestCase):
                                npload.return_value.__getitem__.return_value,
                                fill_value=None)
 
+    @patch.object(mpop.projector.kd_tree, 'get_neighbour_info')
+    def test_calc_nearest_params(self, gni):
+        gni.return_value = (1, 2, 3, 4)
+        res = mpop.projector.calc_nearest_params('in_area', 'out_area',
+                                                 'radius', nprocs='nprocs')
+        self.assertTrue(isinstance(res, dict))
+        self.assertTrue('valid_index' in res)
+        self.assertEqual(res['valid_index'], 1)
+        self.assertTrue('valid_output_index' in res)
+        self.assertEqual(res['valid_output_index'], 2)
+        self.assertTrue('index_array' in res)
+        self.assertEqual(res['index_array'], 3)
+
+    @patch.object(mpop.projector.utils, 'generate_quick_linesample_arrays')
+    def test_calc_quick_params(self, gqla):
+        gqla.return_value = (1, 2)
+        res = mpop.projector.calc_quick_params('in_area', 'out_area')
+
+        self.assertTrue(isinstance(res, dict))
+        self.assertTrue('row_idx' in res)
+        self.assertEqual(res['row_idx'], 1)
+        self.assertTrue('col_idx' in res)
+        self.assertEqual(res['col_idx'], 2)
+
+    @patch.object(mpop.projector, 'get_bil_info')
+    def test_calc_bilinear_params(self, gbi):
+        gbi.return_value = (1, 2, 3, 4)
+        res = mpop.projector.calc_bilinear_params('in_area', 'out_area',
+                                                  'radius', nprocs='nprocs')
+        self.assertTrue(isinstance(res, dict))
+        self.assertTrue('bilinear_t' in res)
+        self.assertEqual(res['bilinear_t'], 1)
+        self.assertTrue('bilinear_s' in res)
+        self.assertEqual(res['bilinear_s'], 2)
+        self.assertTrue('input_idxs' in res)
+        self.assertEqual(res['input_idxs'], 3)
+        self.assertTrue('idx_arr' in res)
+        self.assertEqual(res['idx_arr'], 4)
+
+    @patch.object(mpop.projector, 'll2cr')
+    def test_calc_ewa_params(self, ll2):
+        ll2.return_value = (0, 1, 2)
+        res = mpop.projector.calc_ewa_params('in_area', 'out_area')
+        self.assertTrue(isinstance(res, dict))
+        self.assertTrue('ewa_cols' in res)
+        self.assertEqual(res['ewa_cols'], 1)
+        self.assertTrue('ewa_rows' in res)
+        self.assertEqual(res['ewa_rows'], 2)
+
+    def test_get_precompute_cache_fname(self):
+        res = mpop.projector.get_precompute_cache_fname('in_id', 'out_id',
+                                                        'in_area', 'out_area',
+                                                        'mode', 'proj_dir')
+        cor_res = "proj_dir/in_id2out_id_-" + \
+                  "6296787761359943868to8984161303220364208_mode.npz"
+        self.assertTrue(res == cor_res)
+
+    @patch.object(mpop.projector, 'get_area_def')
+    @patch.object(mpop.projector.geometry, 'SwathDefinition')
+    def test_get_area_and_id(self, swath_def, gad):
+        # Case when get_area_def works
+        swath_def.return_value = 1
+        gad.return_value = 'adef'
+        res = mpop.projector.get_area_and_id('area')
+        self.assertTrue(res[0] == 'adef')
+        self.assertTrue(res[1] == 'area')
+        # Case when AttributeError is raised
+        with self.assertRaises(AttributeError):
+            gad.side_effect = AttributeError
+            res = mpop.projector.get_area_and_id('area')
+        # Case when AttributeError is raised and latlons are given
+        gad.side_effect = AttributeError
+        res = mpop.projector.get_area_and_id('area', latlons=[1, 2])
+        self.assertEqual(res[0], 1)
+        self.assertTrue(res[1], 'area')
+
 
 def random_string(length,
                   choices="abcdefghijklmnopqrstuvwxyz"

--- a/utils/precompute_projection.py
+++ b/utils/precompute_projection.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2017
+#
+# Author(s):
+#
+#   Panu Lahtinen <panu.lahtinen@fmi.fi>
+#
+# This file is part of mpop.
+#
+# mpop is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mpop is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mpop.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Module for calculating and projection mapping look-up tables, which
+can be used with MPOP by setting 'precompute=True'"""
+
+import numpy as np
+import sys
+
+from mpop.projector import (calc_nearest_params,
+                            calc_bilinear_params,
+                            calc_quick_params,
+                            get_precompute_cache_fname,
+                            get_area_and_id)
+
+
+def save(fname, **data):
+    """Save preprojection data to npz file."""
+    np.savez(fname, **data)
+
+
+def calc_preproj_params(out_dir, mode, in_area_name, out_area_name,
+                        radius=None, nprocs=1):
+    """Calculate preprojection parameters and save to *out_dir*"""
+    in_area, in_id = get_area_and_id(in_area_name)
+    out_area, out_id = get_area_and_id(out_area_name)
+
+    fname = get_precompute_cache_fname(in_id, out_id,
+                                       in_area_name, out_area_name,
+                                       mode, out_dir)
+
+    if mode == "nearest":
+        data = calc_nearest_params(in_area, out_area,
+                                   radius, nprocs=nprocs)
+    elif mode == "bilinear":
+        data = calc_bilinear_params(in_area, out_area, radius, nprocs=nprocs)
+    elif mode == "quick":
+        data = calc_quick_params(in_area, out_area)
+
+    save(fname, **data)
+
+
+def print_usage():
+    """Print usage"""
+    print("USAGE:")
+    print("python precompute_projection.py <in_area_name> "
+          "<out_area_name>")
+    print("python precompute_projection.py <in_area_name> "
+          "<out_area_name> <mode>")
+    print("python precompute_projection.py <in_area_name> "
+          "<out_area_name> <mode> <search_radius>")
+    print("python precompute_projection.py <in_area_name> "
+          "<out_area_name> <mode> <search_radius> <nprocs>")
+    print("python precompute_projection.py <in_area_name> "
+          "<out_area_name> <mode> <search_radius> <nprocs> <out_dir>")
+
+
+def main():
+    try:
+        in_area_name = sys.argv[1]
+        out_area_name = sys.argv[2]
+    except IndexError:
+        print_usage()
+        return
+
+    try:
+        mode = sys.argv[3]
+    except IndexError:
+        mode = "nearest"
+    try:
+        radius = int(sys.argv[4])
+    except IndexError:
+        radius = 50000
+    try:
+        nprocs = int(sys.argv[5])
+    except IndexError:
+        nprocs = 1
+
+    try:
+        out_dir = sys.argv[6]
+    except IndexError:
+        out_dir = '.'
+
+    calc_preproj_params(out_dir, mode, in_area_name, out_area_name,
+                        radius=radius, nprocs=nprocs)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request refactors mpop.projector so that more of the internals are usable from the outside. This was done for the utils/precompute_projection.py that can be used to pre-calculate projection LUTs for resampling done between areas defined in areas.def. With large areas the calculation of the LUT can take huge amount of memory, so now the calculations can be done outside the operational environment.

Also, unit tests were added for all the refactored functions.
